### PR TITLE
Prefer the html5 player for hls and dash streams

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -24,7 +24,11 @@ function setupPlayer() {
 	var conf = {
 		key : "YOUR_PLAYER_KEY",
 		playback : {
-			autoplay : true
+			autoplay : true,
+			preferredTech: [
+				{ player: 'html5', streaming: 'hls'},
+				{ player: 'html5', streaming: 'dash'}
+			]
 		},
 		tweaks : {
 			file_protocol : true,


### PR DESCRIPTION
Adding the `preferredTech` section to the playback config to [avoid the issue](https://github.com/bitmovin/player-issues-web/issues/2533) where native player is used.