### PR TITLE
Fix tizen2016 compatibility

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -7,6 +7,8 @@
     <feature name="http://tizen.org/feature/screen.size.normal.1080.1920"/>
     <icon src="bitmovin-icon.png"/>
     <name>TizenBitmovinPlayerAppMode</name>
+    <tizen:privilege name="http://developer.samsung.com/privilege/drmplay"/>
+    <tizen:privilege name="http://tizen.org/privilege/drmplay"/>
     <tizen:privilege name="http://tizen.org/privilege/content.write"/>
     <tizen:privilege name="http://tizen.org/privilege/content.read"/>
     <tizen:privilege name="http://tizen.org/privilege/tv.audio"/>

--- a/js/main.js
+++ b/js/main.js
@@ -41,7 +41,8 @@ function setupPlayer() {
 		tweaks : {
 			file_protocol : true,
 			app_id : "com.bitmovin.demo.webap",
-			BACKWARD_BUFFER_PURGE_INTERVAL: 10
+			BACKWARD_BUFFER_PURGE_INTERVAL: 10,
+            DWORD_BASE_MEDIA_DECODE_TIMESTAMPS: true
 		},
 		},
 		analytics : {

--- a/js/main.js
+++ b/js/main.js
@@ -40,12 +40,11 @@ function setupPlayer() {
 			BACKWARD_BUFFER_PURGE_INTERVAL: 10,
             DWORD_BASE_MEDIA_DECODE_TIMESTAMPS: true
 		},
-		},
 		analytics : {
 		    key: 'YOUR ANALYTICS KEY',
 		    videoId: 'YOUR VIDEO ID',
 		    title: 'A descriptive video title'
-		  }
+	    },
 		buffer: bufferConfig,
 	};
 	

--- a/js/main.js
+++ b/js/main.js
@@ -57,9 +57,9 @@ function setupPlayer() {
 		//DRM AVC Stream
 		dash: 'https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/mpds/11331.mpd',
 		drm: {
-			widevine: {
-		        LA_URL: 'https://widevine-proxy.appspot.com/proxy'
-		    }
+			// widevine support is only acceptable from Tizen2017 onward, use playready instead
+			// widevine: { LA_URL: 'https://widevine-proxy.appspot.com/proxy' }
+			playready: { utf8message: true, plaintextChallenge: true, headers: { 'Content-Type': 'text/xml' } },
 		}
 	}
 		

--- a/js/main.js
+++ b/js/main.js
@@ -33,10 +33,6 @@ function setupPlayer() {
 		key : "YOUR_PLAYER_KEY",
 		playback : {
 			autoplay : true,
-			preferredTech: [
-				{ player: 'html5', streaming: 'hls'},
-				{ player: 'html5', streaming: 'dash'}
-			]
 		},
 		tweaks : {
 			file_protocol : true,

--- a/js/main.js
+++ b/js/main.js
@@ -21,6 +21,14 @@ function setupPlayer() {
 	bitmovin.player.core.Player.addModule(window.bitmovin.player.style.default);
 	bitmovin.player.core.Player.addModule(window.bitmovin.player.tizen.default);
 
+	
+	var bufferConfig = {};
+	var bufferLevels = {};
+	bufferLevels[bitmovin.player.core.BufferType.ForwardDuration] = 30;
+	bufferLevels[bitmovin.player.core.BufferType.BackwardDuration] = 10,
+	bufferConfig[bitmovin.player.core.MediaType.Video] = bufferLevels;
+	bufferConfig[bitmovin.player.core.MediaType.Audio] = bufferLevels;
+	
 	var conf = {
 		key : "YOUR_PLAYER_KEY",
 		playback : {
@@ -35,21 +43,13 @@ function setupPlayer() {
 			app_id : "com.bitmovin.demo.webap",
 			BACKWARD_BUFFER_PURGE_INTERVAL: 10
 		},
-		buffer: {
-			[bitmovin.player.core.MediaType.Video] : {
-				[bitmovin.player.core.BufferType.ForwardDuration] : 30,
-				[bitmovin.player.core.BufferType.BackwardDuration]: 10,
-			},
-			[bitmovin.player.core.MediaType.Audio]: {
-				[bitmovin.player.core.BufferType.ForwardDuration] : 30,
-				[bitmovin.player.core.BufferType.BackwardDuration] : 10,
-			},
 		},
 		analytics : {
 		    key: 'YOUR ANALYTICS KEY',
 		    videoId: 'YOUR VIDEO ID',
 		    title: 'A descriptive video title'
 		  }
+		buffer: bufferConfig,
 	};
 	
 	var source = {

--- a/js/main.js
+++ b/js/main.js
@@ -38,7 +38,7 @@ function setupPlayer() {
 			file_protocol : true,
 			app_id : "com.bitmovin.demo.webap",
 			BACKWARD_BUFFER_PURGE_INTERVAL: 10,
-            DWORD_BASE_MEDIA_DECODE_TIMESTAMPS: true
+			DWORD_BASE_MEDIA_DECODE_TIMESTAMPS: true
 		},
 		analytics : {
 		    key: 'YOUR ANALYTICS KEY',


### PR DESCRIPTION
- Make js code (Buffer config) ES5 compliant
- Enable DRM privilage
- Use playready DRM asset over widevine
- Enable BaseMediaDecodeTime handling explicitly
- Remove outdated explicit setting for preferredTech (that bug has been fixed)