### PR TITLE
Add support for HLS AES-128 encrypted streams

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -3,7 +3,7 @@
     <tizen:allow-navigation>demo.bitmovin.com bitmovin-a.akamaihd.net fonts.googleapis.com cdn.bitmovin.com</tizen:allow-navigation>
     <tizen:application id="sMulUBHvPv.TizenBitmovinPlayerAppMode" package="sMulUBHvPv" required_version="2.3"/>
     <content src="index.html"/>
-    <tizen:content-security-policy>script-src 'self' 'unsafe-inline' https://cdn.bitmovin.com/</tizen:content-security-policy>
+    <tizen:content-security-policy>script-src 'self' 'unsafe-inline' https://cdn.bitmovin.com/ blob: data:</tizen:content-security-policy>
     <feature name="http://tizen.org/feature/screen.size.normal.1080.1920"/>
     <icon src="bitmovin-icon.png"/>
     <name>TizenBitmovinPlayerAppMode</name>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
     <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-xml.js"></script>
     <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-dash.js"></script>
     <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-hls.js"></script>
+    <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-crypto.js"></script>
     <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-style.js"></script>
     <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-smooth.js"></script>
     <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-tizen.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -18,6 +18,7 @@ function setupPlayer() {
 	bitmovin.player.core.Player.addModule(window.bitmovin.player.xml.default);
 	bitmovin.player.core.Player.addModule(window.bitmovin.player.dash.default);
 	bitmovin.player.core.Player.addModule(window.bitmovin.player.hls.default);
+	bitmovin.player.core.Player.addModule(window.bitmovin.player.crypto.default);
 	bitmovin.player.core.Player.addModule(window.bitmovin.player.style.default);
 	bitmovin.player.core.Player.addModule(window.bitmovin.player.tizen.default);
 


### PR DESCRIPTION
- Crypto module was not loaded
- `data:` and `blob:` URIs weren't allowed by the CSP, thus creating the web worker for MPEG-TS transmuxing wouldn't work