### PR TITLE
Add Engine Native module for progressive stream

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-polyfill.js"></script>
     <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-engine-bitmovin.js"></script>
     <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-mserenderer.js"></script>
+    <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-engine-native.js"></script>
     <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-abr.js"></script>
     <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-drm.js"></script>
     <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-container-mp4.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -62,7 +62,11 @@ function setupPlayer() {
 			// widevine support is only acceptable from Tizen2017 onward, use playready instead
 			// widevine: { LA_URL: 'https://widevine-proxy.appspot.com/proxy' }
 			playready: { utf8message: true, plaintextChallenge: true, headers: { 'Content-Type': 'text/xml' } },
-		}
+		},
+		progressive: [{
+			url: 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
+			type: 'video/mp4',
+		}],
 	}
 		
 

--- a/js/main.js
+++ b/js/main.js
@@ -10,6 +10,7 @@ function setupPlayer() {
 	// add all necessary (and loaded) modules to the player core
 	bitmovin.player.core.Player.addModule(window.bitmovin.player.polyfill.default);
 	bitmovin.player.core.Player.addModule(window.bitmovin.player['engine-bitmovin'].default);
+	bitmovin.player.core.Player.addModule(window.bitmovin.player['engine-native'].default);
 	bitmovin.player.core.Player.addModule(window.bitmovin.player['container-mp4'].default);
 	bitmovin.player.core.Player.addModule(window.bitmovin.player['container-ts'].default);
 	bitmovin.player.core.Player.addModule(window.bitmovin.player.mserenderer.default);


### PR DESCRIPTION
mp4 stream is not able to play in the sample due to missing module - Engine Native.

### Added
- Engine Native module
- mp4 test stream from https://bitmovin.com/demos/stream-test