### PR TITLE
Fix error & warning listeners

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -77,11 +77,11 @@ function setupPlayer() {
 		console.log("Error while creating bitmovin player instance");
 	});
 	
-	player.on(bitmovin.player.core.PlayerEvent.OnWarning, function(data) {
+	player.on(bitmovin.player.core.PlayerEvent.Warning, function(data) {
         console.log("On Warning: "+JSON.stringify(data))
     });
 	
-	player.on(bitmovin.player.core.PlayerEvent.OnError, function(data) {
+	player.on(bitmovin.player.core.PlayerEvent.Error, function(data) {
         console.log("On Error: "+JSON.stringify(data));
     });
 }


### PR DESCRIPTION
The warning and error should be `Warning` and `Error`.

https://bitmovin.com/docs/player/api-reference/web/web-sdk-v8-api-methods#/player/web/8/docs/enums/core_events.playerevent.html#warning

https://bitmovin.com/docs/player/api-reference/web/web-sdk-v8-api-methods#/player/web/8/docs/enums/core_events.playerevent.html#error